### PR TITLE
[DT-60] react native에서 웹뷰 url을 환경변수로 관리할 수 있도록 env 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,6 @@ dist
 
 # vuepress v2.x temp and cache directory
 .temp
-.cache
 
 # Docusaurus cache and generated files
 .docusaurus
@@ -126,7 +125,6 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .yarn/install-state.gz
-.pnp.*
 
 docs/infra/local/cert/
 .idea
@@ -146,3 +144,5 @@ yarn-error.log
 **/.eslintcache
 
 __pycache__
+
+tunnel.yml

--- a/package.json
+++ b/package.json
@@ -23,8 +23,15 @@
     "dev": "concurrently -c \"bgGreen.bold,bgMagenta.bold,bgYellow.bold,bgBlue.bold\" \"yarn:run-*\"",
     "run-web": "yarn @finfriends-frontend/web dev",
     "run-app": "yarn @finfriends-frontend/app start",
-    "android": "yarn @finfriends-frontend/app android",
-    "ios": "yarn @finfriends-frontend/app ios"
+    "android:dev:d": "yarn @finfriends-frontend/app android:dev:d",
+    "android:dev:r": "yarn @finfriends-frontend/app android:dev:r",
+    "android:prd:d": "yarn @finfriends-frontend/app android:prd:d",
+    "android:prd:r": "yarn @finfriends-frontend/app android:prd:r",
+    "ios": "yarn @finfriends-frontend/app ios",
+    "ios:dev:d": "yarn @finfriends-frontend/app ios:dev:d",
+    "ios:dev:r": "yarn @finfriends-frontend/app ios:dev:r",
+    "ios:prd:d": "yarn @finfriends-frontend/app ios:prd:d",
+    "ios:prd:r": "yarn @finfriends-frontend/app ios:prd:r"
   },
   "packageManager": "yarn@4.3.0"
 }

--- a/src/app/.gitignore
+++ b/src/app/.gitignore
@@ -71,3 +71,5 @@ yarn-error.log
 !.yarn/plugins
 !.yarn/sdks
 !.yarn/versions
+
+ios/tmp.xcconfig

--- a/src/app/android/app/build.gradle
+++ b/src/app/android/app/build.gradle
@@ -2,6 +2,17 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
+project.ext.envConfigFiles = [
+    developdebug: "env/.env.develop",
+    developrelease: "env/.env.develop",
+    productdebug: "env/.env.product",
+    productrelease: "env/.env.product",
+    anothercustombuild: ".env",
+]
+
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
+
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.
@@ -73,6 +84,14 @@ def enableProguardInReleaseBuilds = false
 def jscFlavor = 'org.webkit:android-jsc:+'
 
 android {
+    flavorDimensions "version"
+    productFlavors {
+        develop {
+        }
+        product {
+        }
+    }
+
     ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion

--- a/src/app/components/WebViewCont.tsx
+++ b/src/app/components/WebViewCont.tsx
@@ -4,10 +4,10 @@ import {WebView} from 'react-native-webview';
 import styled from '@emotion/native';
 import {handleDataFromWeb} from '../libs/handleDataFromWeb.ts';
 import {WebViewEventType} from '../types/message.ts';
+import Config from 'react-native-config';
 
 export const WebViewCont = () => {
-  // adb reverse tcp:3000 tcp:3000
-  const webUrl: string = 'http://localhost:3000';
+  const webUrl: string = Config.RN_APP_WEB_VIEW_URL || '';
   const webviewRef = useRef<WebView | null>(null);
   const fetchDataFromWeb = (e: WebViewEventType) => {
     const data = handleDataFromWeb(e.nativeEvent.data);

--- a/src/app/env/.env.develop
+++ b/src/app/env/.env.develop
@@ -1,0 +1,1 @@
+RN_APP_WEB_VIEW_URL=https://jes.finfriends.site

--- a/src/app/env/.env.product
+++ b/src/app/env/.env.product
@@ -1,0 +1,1 @@
+RN_APP_WEB_VIEW_URL=https://app.finfriends.site

--- a/src/app/ios/Config.xcconfig
+++ b/src/app/ios/Config.xcconfig
@@ -1,0 +1,10 @@
+//
+//  Config.xcconfig
+//  app
+//
+//  Created by 정은솔 on 10/6/24.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+#include? "tmp.xcconfig"

--- a/src/app/ios/Podfile.lock
+++ b/src/app/ios/Podfile.lock
@@ -1237,7 +1237,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-webview (13.12.2):
+  - react-native-config (1.5.3):
+    - react-native-config/App (= 1.5.3)
+  - react-native-config/App (1.5.3):
+    - React-Core
+  - react-native-webview (13.12.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1559,6 +1563,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - react-native-config (from `../node_modules/react-native-config`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-nativeconfig (from `../node_modules/react-native/ReactCommon`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
@@ -1664,6 +1669,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  react-native-config:
+    :path: "../node_modules/react-native-config"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
   React-nativeconfig:
@@ -1757,7 +1764,8 @@ SPEC CHECKSUMS:
   React-logger: 4072f39df335ca443932e0ccece41fbeb5ca8404
   React-Mapbuffer: 714f2fae68edcabfc332b754e9fbaa8cfc68fdd4
   React-microtasksnativemodule: 4943ad8f99be8ccf5a63329fa7d269816609df9e
-  react-native-webview: 7aaf4bb5b2ec08901c821aceb4b55908ad012b04
+  react-native-config: 8f7283449bbb048902f4e764affbbf24504454af
+  react-native-webview: 282ea79c56ea6b32380dd4464e0f4accf50b224d
   React-nativeconfig: 4a9543185905fe41014c06776bf126083795aed9
   React-NativeModulesApple: 0506da59fc40d2e1e6e12a233db5e81c46face27
   React-perflogger: 3bbb82f18e9ac29a1a6931568e99d6305ef4403b

--- a/src/app/ios/app.xcodeproj/project.pbxproj
+++ b/src/app/ios/app.xcodeproj/project.pbxproj
@@ -12,9 +12,9 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		4C9B7EEE7D2AECBE3BEFB605 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0F356F7B7CE9686C59782A40 /* PrivacyInfo.xcprivacy */; };
+		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		CE99874019379574B7C9B1E2 /* libPods-app.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5970E7361601FD7AA1D9399E /* libPods-app.a */; };
 		FD4273AF176E176D10E5FFEA /* libPods-app-appTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AF8F1C0B9F7631CED8882AAC /* libPods-app-appTests.a */; };
-		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,7 +31,7 @@
 		00E356EE1AD99517003FC87E /* appTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = appTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* appTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = appTests.m; sourceTree = "<group>"; };
-		0F356F7B7CE9686C59782A40 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = app/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		0F356F7B7CE9686C59782A40 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = app/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = app.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = app/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = app/AppDelegate.mm; sourceTree = "<group>"; };
@@ -41,6 +41,7 @@
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = app/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		430ACC257535B6E8FE5FD5CA /* Pods-app.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-app.debug.xcconfig"; path = "Target Support Files/Pods-app/Pods-app.debug.xcconfig"; sourceTree = "<group>"; };
 		44E3ADE3340FD210B9046738 /* Pods-app-appTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-app-appTests.release.xcconfig"; path = "Target Support Files/Pods-app-appTests/Pods-app-appTests.release.xcconfig"; sourceTree = "<group>"; };
+		4D6A2DF52CB22B0400212F62 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		5970E7361601FD7AA1D9399E /* libPods-app.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-app.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = app/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		93885B4ED91CBFA9894EF2E2 /* Pods-app-appTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-app-appTests.debug.xcconfig"; path = "Target Support Files/Pods-app-appTests/Pods-app-appTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -121,6 +122,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				4D6A2DF52CB22B0400212F62 /* Config.xcconfig */,
 				13B07FAE1A68108700A75B9A /* app */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* appTests */,
@@ -519,6 +521,7 @@
 		};
 		83CBBA201A601CBA00E9B192 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4D6A2DF52CB22B0400212F62 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CC = "";
@@ -568,7 +571,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -590,10 +593,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -603,6 +603,7 @@
 		};
 		83CBBA211A601CBA00E9B192 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4D6A2DF52CB22B0400212F62 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CC = "";
@@ -645,7 +646,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -666,10 +667,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/src/app/ios/app.xcodeproj/xcshareddata/xcschemes/Develop.xcscheme
+++ b/src/app/ios/app.xcodeproj/xcshareddata/xcschemes/Develop.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Type a script or drag a script file from your workspace to insert its path.&#10;cp &quot;${PROJECT_DIR}/../env/.env.develop&quot; &quot;${PROJECT_DIR}/../.env&quot;&#10;&#10;&quot;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb&quot; &quot;${SRCROOT}/..&quot; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+                     BuildableName = "app.app"
+                     BlueprintName = "app"
+                     ReferencedContainer = "container:app.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "app.app"
+               BlueprintName = "app"
+               ReferencedContainer = "container:app.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "app.app"
+            BlueprintName = "app"
+            ReferencedContainer = "container:app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "app.app"
+            BlueprintName = "app"
+            ReferencedContainer = "container:app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/app/ios/app.xcodeproj/xcshareddata/xcschemes/Product.xcscheme
+++ b/src/app/ios/app.xcodeproj/xcshareddata/xcschemes/Product.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Type a script or drag a script file from your workspace to insert its path.&#10;cp &quot;${PROJECT_DIR}/../env/.env.product&quot; &quot;${PROJECT_DIR}/../.env&quot;&#10;&#10;&quot;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb&quot; &quot;${SRCROOT}/..&quot; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+                     BuildableName = "app.app"
+                     BlueprintName = "app"
+                     ReferencedContainer = "container:app.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "app.app"
+               BlueprintName = "app"
+               ReferencedContainer = "container:app.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "app.app"
+            BlueprintName = "app"
+            ReferencedContainer = "container:app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "app.app"
+            BlueprintName = "app"
+            ReferencedContainer = "container:app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -3,8 +3,14 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "android:dev:d": "react-native run-android --mode=developdebug",
+    "android:dev:r": "react-native run-android --mode=developrelease",
+    "android:prd:d": "react-native run-android --mode=productdebug",
+    "android:prd:r": "react-native run-android --mode=productrelease",
+    "ios:dev:d": "react-native run-ios --scheme Develop --mode Debug",
+    "ios:dev:r": "react-native run-ios --scheme Develop --mode Release",
+    "ios:prd:d": "react-native run-ios --scheme Product --mode Debug",
+    "ios:prd:r": "react-native run-ios --scheme Product --mode Release",
     "lint": "eslint ./ --quiet --cache --fix",
     "ts-check": "tsc --project ./tsconfig.json --noEmit",
     "start": "react-native start"
@@ -14,7 +20,8 @@
     "@emotion/react": "^11.13.3",
     "react": "18.3.1",
     "react-native": "0.75.3",
-    "react-native-webview": "^13.12.1"
+    "react-native-config": "1.5.3",
+    "react-native-webview": "13.12.1"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",

--- a/src/web/.env.development
+++ b/src/web/.env.development
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_URL=https://api.finfriends.site/api
+NEXT_PUBLIC_API_URL=https://test-api.finfriends.site/api

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,7 +1805,8 @@ __metadata:
     prettier: "npm:3.3.3"
     react: "npm:18.3.1"
     react-native: "npm:0.75.3"
-    react-native-webview: "npm:^13.12.1"
+    react-native-config: "npm:1.5.3"
+    react-native-webview: "npm:13.12.1"
     react-test-renderer: "npm:18.3.1"
     typescript: "npm:5.0.4"
   languageName: unknown
@@ -8816,16 +8817,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:^13.12.1":
-  version: 13.12.2
-  resolution: "react-native-webview@npm:13.12.2"
+"react-native-config@npm:1.5.3":
+  version: 1.5.3
+  resolution: "react-native-config@npm:1.5.3"
+  peerDependencies:
+    react-native-windows: ">=0.61"
+  peerDependenciesMeta:
+    react-native-windows:
+      optional: true
+  checksum: 10/ba5e38c907fa39ea072238a12bf4d5fca88e92bc8192974c7aceeadf814cf9f452dc30bcf705819d778c6e69ac2df699960c044f1c8c0c69cd5a8bcc9b7f555a
+  languageName: node
+  linkType: hard
+
+"react-native-webview@npm:13.12.1":
+  version: 13.12.1
+  resolution: "react-native-webview@npm:13.12.1"
   dependencies:
     escape-string-regexp: "npm:^4.0.0"
     invariant: "npm:2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/a1217943be1b04f43e6e9f506a5b0a1da119428f477d7de1ee9abec956641e07c611e090b1ed94bd54bd82a4cf7cd1830b8d69e835a9e3532f2a53bdef0b3839
+  checksum: 10/08d792f99cb77ca3541f79c71c253504198d511ed45baf319ee34a494b63ec42a73aa0ac3532fa18825b47c177e9028a6fe5455395b8aa8602aa7abe041871ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
react native 웹뷰 연결해주실 때 로컬 호스트로 하드코딩 되어 있었던 건 이제 RN 빌드 시 빌드 환경 구분이 필요해서 env 셋팅 해두었습니다. 크게 develop, stage, product로 나뉘는데 저희는 stage까지는 아직 불필요할 것 같아서 스킴을 develop이랑 product 두개로 변경했어요. 하면서 yarn 명령어도 그에 맞추어서 4가지(develop env의 디버그 모드, 릴리즈 모드, product env의 디버그 모드, 릴리즈 모드)로 구분해서 실행할 수 있도록 수정해두었어요. 일단 제 로컬에서 총 8개 명령어 실행했을 땐 잘 동작해서 동우님도 확인해보시고 알려주시면 될 것 같습니다.

추가로 터널링 시 추가해야 하는 tunnel.yml 파일은 ignore 해뒀으니 동우님도 터널링 셋팅하실 때 작업하시면 알아서 ignore 될 거예요.

아까 지수님이 test api 서버 바꿨다 하셔서 그것도 추가로 수정해두었습니다.